### PR TITLE
Add more flexible inputs, and handle transparent images

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -556,13 +556,13 @@ class Predictor(BasePredictor):
             default=512,
             description="The width of the generated images in pixels",
             ge=100,
-            le=1024,
+            le=1280,
         ),
         height: int = Input(
             default=640,
             description="The height of the generated images in pixels",
             ge=100,
-            le=1024
+            le=1280
         ),
         steps: int = Input(
             default=25,
@@ -616,7 +616,7 @@ class Predictor(BasePredictor):
         ),
         output_quality: int = Input(
             description="The image compression quality (for lossy formats like JPEG and WebP). 100 = best quality, 0 = lowest quality.",
-            default=80,
+            default=100,
             ge=0,
             le=100,
         ),

--- a/predict.py
+++ b/predict.py
@@ -555,12 +555,14 @@ class Predictor(BasePredictor):
         width: int = Input(
             default=512,
             description="The width of the generated images in pixels",
-            choices=[256, 320, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024],
+            ge=100,
+            le=1024,
         ),
         height: int = Input(
             default=640,
             description="The height of the generated images in pixels",
-            choices=[256, 320, 384, 448, 512, 576, 640, 704, 768, 832, 896, 960, 1024],
+            ge=100,
+            le=1024
         ),
         steps: int = Input(
             default=25,

--- a/predict.py
+++ b/predict.py
@@ -142,7 +142,11 @@ def resize_without_crop(image, target_width, target_height):
 @torch.inference_mode()
 def run_rmbg(img, sigma=0.0):
     H, W, C = img.shape
-    assert C == 3
+
+    if C != 3:
+        img = Image.fromarray(img).convert("RGB")
+        img = np.array(img)
+
     k = (256.0 / float(H * W)) ** 0.5
     feed = resize_without_crop(img, int(64 * round(W * k)), int(64 * round(H * k)))
     feed = numpy2pytorch([feed]).to(device=device, dtype=torch.float32)
@@ -562,7 +566,7 @@ class Predictor(BasePredictor):
             default=640,
             description="The height of the generated images in pixels",
             ge=100,
-            le=1280
+            le=1280,
         ),
         steps: int = Input(
             default=25,
@@ -682,7 +686,7 @@ class Predictor(BasePredictor):
         # Image.fromarray(output_bg).save(bg_path, **save_params)
 
         # Save the generated images
-        output_paths = [] #[Path(bg_path)]
+        output_paths = []  # [Path(bg_path)]
         for i, img in enumerate(result_gallery):
             img_path = os.path.join(output_dir, f"generated_{i}.{extension}")
             print(f"[~] Saving to {img_path}...")


### PR DESCRIPTION
I ran into some problems using the model with images of non-standard resolutions and that contained an alpha channel, so I loosened up the input checking and the ability to convert to RGB instead of erroring out.

Thanks for making this cog!